### PR TITLE
Add test to verify that Object.assign_id() works with FileContentSource.

### DIFF
--- a/src/object.rs
+++ b/src/object.rs
@@ -489,6 +489,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(tarpaulin, skip)]
     fn assign_id_from_file() {
         let dir = TempDir::new().unwrap();
         let path = dir.as_ref().join("example");


### PR DESCRIPTION
(It does.)

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- [x] There is test coverage for all changes.
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
