### PR TITLE
Implement Attribution::parse().

### DIFF
--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -1,4 +1,7 @@
 use std::fmt;
+use std::io::BufRead;
+use std::str::{self, FromStr};
+use std::string::String;
 
 /// An `Attribution` combines a person's identity (name and e-mail address)
 /// with the timestamp for a particular action.
@@ -27,6 +30,52 @@ impl Attribution {
             timestamp,
             tz_offset,
         }
+    }
+
+    /// Parse a name line (e.g. author, committer, tagger) into an `Attribution` struct.
+    /// Returns `None` if unable to parse the line properly.
+    pub fn parse(b: &mut dyn BufRead) -> Option<Attribution> {
+        let mut line: Vec<u8> = Vec::new();
+        if b.read_until(10, &mut line).is_err() {
+            return None;
+        };
+
+        let (name, line) = split_once(line.as_slice(), &b'<');
+        let name = drop_last_space(name);
+        let name = match str::from_utf8(name) {
+            Ok(name_str) => name_str.to_string(),
+            _ => return None,
+        };
+
+        if !line.contains(&b'>') {
+            return None;
+        }
+
+        let (email, line) = split_once(line, &b'>');
+        let email = match str::from_utf8(email) {
+            Ok(email_str) => email_str.to_string(),
+            _ => return None,
+        };
+
+        let line = drop_last_space(line);
+        let (tz_offset, line) = last_word(line);
+        let tz_offset = match tz_from_str(tz_offset.as_str()) {
+            Some(t) => t,
+            _ => 0,
+        };
+
+        let (timestamp, _line) = last_word(line);
+        let timestamp = match i64::from_str(timestamp.as_str()) {
+            Ok(t) => t,
+            _ => 0,
+        };
+
+        Some(Attribution {
+            name,
+            email,
+            timestamp,
+            tz_offset,
+        })
     }
 
     /// Returns the person's human-readable name.
@@ -71,6 +120,71 @@ impl Attribution {
     }
 }
 
+fn split_once<'a>(s: &'a [u8], c: &u8) -> (&'a [u8], &'a [u8]) {
+    match s.iter().position(|b| b == c) {
+        Some(n) => (&s[0..n], &s[n + 1..]),
+        None => (s, &[]),
+    }
+}
+
+fn drop_last_space<'a>(s: &'a [u8]) -> &'a [u8] {
+    if s.last() == Some(&b' ') {
+        &s[0..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+fn last_word<'a>(s: &'a [u8]) -> (String, &'a [u8]) {
+    let s = match s.iter().position(|b| b != &b' ') {
+        Some(n) => &s[n..],
+        None => s,
+    };
+
+    let (word, line) = rsplit_once(s, &b' ');
+    let word = match str::from_utf8(word) {
+        Ok(word_str) => word_str.to_string(),
+        _ => "".to_string(),
+    };
+
+    (word, line)
+}
+
+fn rsplit_once<'a>(s: &'a [u8], c: &u8) -> (&'a [u8], &'a [u8]) {
+    match s.iter().rev().position(|b| b == c) {
+        Some(n) => (&s[s.len() - n..], &s[0..s.len() - n - 1]),
+        None => (s, &[]),
+    }
+}
+
+fn tz_from_str(s: &str) -> Option<i16> {
+    let s = s.as_bytes();
+
+    if s.len() != 5 {
+        return None;
+    }
+
+    let sign: i16 = match &s[0..1] {
+        b"+" => 1,
+        b"-" => -1,
+        _ => {
+            return None;
+        }
+    };
+
+    let hh = from_digit(s[1]) * 10 + from_digit(s[2]);
+    let mm = from_digit(s[3]) * 10 + from_digit(s[3]);
+    Some(sign * (hh * 60 + mm))
+}
+
+fn from_digit(digit: u8) -> i16 {
+    if digit >= 48 && digit <= 57 {
+        (digit as i16) - 48
+    } else {
+        0
+    }
+}
+
 fn sanitize(s: &str) -> String {
     let mut result = String::new();
     for c in s.trim().chars() {
@@ -96,7 +210,7 @@ impl fmt::Display for Attribution {
             "{} <{}> {} {}",
             sanitize(&self.name),
             sanitize(&self.email),
-            self.timestamp / 1000,
+            self.timestamp,
             self.format_tz()
         )
     }
@@ -106,13 +220,15 @@ impl fmt::Display for Attribution {
 mod tests {
     use super::Attribution;
 
+    use std::io::Cursor;
+
     #[test]
     fn happy_path() {
-        let a = Attribution::new("A U Thor", "author@example.com", 1_142_878_501_000, 150);
+        let a = Attribution::new("A U Thor", "author@example.com", 1_142_878_501, 150);
 
         assert_eq!(a.name(), "A U Thor");
         assert_eq!(a.email(), "author@example.com");
-        assert_eq!(a.timestamp(), 1_142_878_501_000);
+        assert_eq!(a.timestamp(), 1_142_878_501);
         assert_eq!(a.tz_offset(), 150);
 
         assert_eq!(
@@ -122,13 +238,210 @@ mod tests {
     }
 
     #[test]
+    fn parse_legal_cases() {
+        let line = b"Me <me@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b" Me <me@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), " Me");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor <author@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor<author@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor<author@example.com>1234567890 +0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), 420);
+
+        let line = b" A U Thor   < author@example.com > 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), " A U Thor  ");
+        assert_eq!(a.email(), " author@example.com ");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor<author@example.com>1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+    }
+
+    #[test]
+    fn parse_fuzzy_cases() {
+        let line =
+            b"A U Thor <author@example.com>,  C O. Miter <comiter@example.com> 1234567890 -0700"
+                .to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor <author@example.com> and others 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+    }
+
+    #[test]
+    fn parse_incomplete_cases() {
+        let line = b"Me <> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b" <me@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b" <> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+
+        let line = b"<>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b" <>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b"<me@example.com>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b" <me@example.com>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b"Me <>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b"Me <me@example.com>".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b"Me <me@example.com> 1234567890".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+
+        let line = b"Me <me@example.com> 1234567890 ".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "Me");
+        assert_eq!(a.email(), "me@example.com");
+        assert_eq!(a.timestamp(), 0);
+        assert_eq!(a.tz_offset(), 0);
+    }
+
+    #[test]
+    fn parse_malformed_cases() {
+        let line = b"Me me@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        assert!(Attribution::parse(&mut c).is_none());
+
+        let line = b"Me <me@example.com 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        assert!(Attribution::parse(&mut c).is_none());
+    }
+
+    #[test]
     fn sanitize() {
-        let a1 = Attribution::new(
-            " A U \x0CThor ",
-            " author@example.com",
-            1_142_878_501_000,
-            150,
-        );
+        let a1 = Attribution::new(" A U \x0CThor ", " author@example.com", 1_142_878_501, 150);
 
         assert_eq!(a1.name(), " A U \x0CThor ");
         assert_eq!(a1.email(), " author@example.com");
@@ -136,12 +449,7 @@ mod tests {
         assert_eq!(a1.sanitized_name(), "A U Thor");
         assert_eq!(a1.sanitized_email(), "author@example.com");
 
-        let a2 = Attribution::new(
-            " A U <Thor> ",
-            " author@example.com",
-            1_142_878_501_000,
-            150,
-        );
+        let a2 = Attribution::new(" A U <Thor> ", " author@example.com", 1_142_878_501, 150);
 
         assert_eq!(a2.name(), " A U <Thor> ");
         assert_eq!(a2.email(), " author@example.com");
@@ -152,60 +460,55 @@ mod tests {
 
     #[test]
     fn format_tz() {
-        let a1 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501_000, 150);
+        let a1 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501, 150);
         assert_eq!(a1.format_tz(), "+0230");
 
-        let a2 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501_000, 0);
+        let a2 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501, 0);
         assert_eq!(a2.format_tz(), "+0000");
 
-        let a3 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501_000, -420);
+        let a3 = Attribution::new("A U Thor", "author@example.com", 1_142_878_501, -420);
         assert_eq!(a3.format_tz(), "-0700");
     }
 
     #[test]
     fn trims_all_whitespace() {
-        let a = Attribution::new("  \u{0001} \n ", "  \u{0001} \n ", 1_142_878_501_000, 0);
+        let a = Attribution::new("  \u{0001} \n ", "  \u{0001} \n ", 1_142_878_501, 0);
         assert_eq!(a.to_string(), " <> 1142878501 +0000");
     }
 
     #[test]
     fn trims_other_bad_chars() {
-        let a = Attribution::new(
-            " Foo\r\n<Bar> ",
-            " Baz>\n\u{1234}<Quux ",
-            1_142_878_501_000,
-            0,
-        );
+        let a = Attribution::new(" Foo\r\n<Bar> ", " Baz>\n\u{1234}<Quux ", 1_142_878_501, 0);
         assert_eq!(a.to_string(), "Foo\rBar <Baz\u{1234}Quux> 1142878501 +0000");
     }
 
     #[test]
     fn accepts_empty_name_and_email() {
-        let a = Attribution::new("", "", 1_142_878_501_000, 0);
+        let a = Attribution::new("", "", 1_142_878_501, 0);
         assert_eq!(a.to_string(), " <> 1142878501 +0000");
     }
 
     #[test]
     fn accepts_gmt_minus_12_hours() {
-        let a = Attribution::new("", "", 1_142_878_501_000, -720);
+        let a = Attribution::new("", "", 1_142_878_501, -720);
         assert_eq!(a.to_string(), " <> 1142878501 -1200");
     }
 
     #[test]
     fn accepts_gmt_plus_14_hours() {
-        let a = Attribution::new("", "", 1_142_878_501_000, 840);
+        let a = Attribution::new("", "", 1_142_878_501, 840);
         assert_eq!(a.to_string(), " <> 1142878501 +1400");
     }
 
     #[test]
     #[should_panic(expected = "Illegal time zone offset: -721")]
     fn panics_on_illegal_negative_tz() {
-        let _a = Attribution::new("", "", 1_142_878_501_000, -721);
+        let _a = Attribution::new("", "", 1_142_878_501, -721);
     }
 
     #[test]
     #[should_panic(expected = "Illegal time zone offset: 841")]
     fn panics_on_illegal_positive_tz() {
-        let _a = Attribution::new("", "", 1_142_878_501_000, 841);
+        let _a = Attribution::new("", "", 1_142_878_501, 841);
     }
 }

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -333,6 +333,17 @@ mod tests {
         assert_eq!(a.email(), "author@example.com");
         assert_eq!(a.timestamp(), 1234567890);
         assert_eq!(a.tz_offset(), 0);
+    }
+
+    #[test]
+    fn parse_bad_utf8() {
+        let line = b"M\xE2 <me@example.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        assert_eq!(Attribution::parse(&mut c), None);
+
+        let line = b"Me <me@e\x88ample.com> 1234567890 -0700".to_vec();
+        let mut c = Cursor::new(&line);
+        assert_eq!(Attribution::parse(&mut c), None);
 
         let line = b"A U Thor <author@example.com> and others 1234567890 -07z0".to_vec();
         let mut c = Cursor::new(&line);

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -343,6 +343,16 @@ mod tests {
         assert_eq!(a.timestamp(), 1234567890);
         assert_eq!(a.tz_offset(), -420);
         // undefined behavior; this is "reasonable" I guess
+
+        let line = b"A U Thor<author@example.com>1234567890 -0\xA700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), 0);
+        // Should be zero'd out because TZ isn't valid UTF8.
     }
 
     #[test]

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -324,6 +324,15 @@ mod tests {
         assert_eq!(a.email(), "author@example.com");
         assert_eq!(a.timestamp(), 1234567890);
         assert_eq!(a.tz_offset(), -420);
+
+        let line = b"A U Thor <author@example.com> and others 1234567890 ~0700".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), 0);
     }
 
     #[test]

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -127,7 +127,7 @@ fn split_once<'a>(s: &'a [u8], c: &u8) -> (&'a [u8], &'a [u8]) {
     }
 }
 
-fn drop_last_space<'a>(s: &'a [u8]) -> &'a [u8] {
+fn drop_last_space(s: &[u8]) -> &[u8] {
     if s.last() == Some(&b' ') {
         &s[0..s.len() - 1]
     } else {
@@ -135,7 +135,7 @@ fn drop_last_space<'a>(s: &'a [u8]) -> &'a [u8] {
     }
 }
 
-fn last_word<'a>(s: &'a [u8]) -> (String, &'a [u8]) {
+fn last_word(s: &[u8]) -> (String, &[u8]) {
     let s = match s.iter().position(|b| b != &b' ') {
         Some(n) => &s[n..],
         None => s,

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -336,6 +336,21 @@ mod tests {
     }
 
     #[test]
+    fn parse_io_error() {
+        use std::io::{BufReader, Error, ErrorKind, Read, Result};
+
+        struct Broken;
+        impl Read for Broken {
+            fn read(&mut self, _buf: &mut [u8]) -> Result<usize> {
+                Err(Error::new(ErrorKind::BrokenPipe, "uh-oh!"))
+            }
+        }
+        let mut b = BufReader::new(Broken);
+
+        assert_eq!(Attribution::parse(&mut b), None);
+    }
+
+    #[test]
     fn parse_bad_utf8() {
         let line = b"M\xE2 <me@example.com> 1234567890 -0700".to_vec();
         let mut c = Cursor::new(&line);

--- a/src/attribution.rs
+++ b/src/attribution.rs
@@ -333,6 +333,16 @@ mod tests {
         assert_eq!(a.email(), "author@example.com");
         assert_eq!(a.timestamp(), 1234567890);
         assert_eq!(a.tz_offset(), 0);
+
+        let line = b"A U Thor <author@example.com> and others 1234567890 -07z0".to_vec();
+        let mut c = Cursor::new(&line);
+        let a = Attribution::parse(&mut c).unwrap();
+
+        assert_eq!(a.name(), "A U Thor");
+        assert_eq!(a.email(), "author@example.com");
+        assert_eq!(a.timestamp(), 1234567890);
+        assert_eq!(a.tz_offset(), -420);
+        // undefined behavior; this is "reasonable" I guess
     }
 
     #[test]


### PR DESCRIPTION
## Changes in This Pull Request
This can parse the name line (author, committer, tagger) from a commit or tag object into an Attribution struct.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
