### PR TITLE
Fix unintended panic in GitPathSegment::new_with_platform_checks.

### DIFF
--- a/src/git_path.rs
+++ b/src/git_path.rs
@@ -355,7 +355,7 @@ fn check_git_path_with_mac_ignorables(segment: &[u8]) -> Result<(), GitPathError
 }
 
 fn check_truncated_utf8_for_mac(segment: &[u8]) -> Result<(), GitPathError> {
-    let tail3 = &segment[0.max(segment.len() - 2)..];
+    let tail3 = &segment[2.max(segment.len()) - 2..];
     if tail3.contains(&0xE2) || tail3.contains(&0xEF) {
         Err(GitPathError::ContainsIncompleteUnicodeCharacters)
     } else {
@@ -718,7 +718,7 @@ mod path_tests {
         ".git\u{FEFF}",
     ];
 
-    const ALMOST_MAC_HFS_GIT_NAMES: [&str; 3] = [".gi", ".git\u{200C}x", ".kit\u{200C}"];
+    const ALMOST_MAC_HFS_GIT_NAMES: [&str; 4] = ["g", ".gi", ".git\u{200C}x", ".kit\u{200C}"];
 
     #[test]
     fn mac_variations_on_dot_git_name() {
@@ -1127,7 +1127,7 @@ mod path_segment_tests {
         ".git\u{FEFF}",
     ];
 
-    const ALMOST_MAC_HFS_GIT_NAMES: [&str; 3] = [".gi", ".git\u{200C}x", ".kit\u{200C}"];
+    const ALMOST_MAC_HFS_GIT_NAMES: [&str; 4] = ["g", ".gi", ".git\u{200C}x", ".kit\u{200C}"];
 
     #[test]
     fn mac_variations_on_dot_git_name() {


### PR DESCRIPTION
## Changes in This Pull Request
Would panic (unsigned subtraction underflow) if the path was too short.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- ~All applicable changes have been documented.~ _n/a_
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
