### PR TITLE
Upgrade to cargo-tarpaulin 0.13.3.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run cargo-tarpaulin
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.9.0'
+          version: '0.13.3'
           args: '--ignore-tests -- --test-threads 1'
 
       - name: Upload to codecov.io


### PR DESCRIPTION
Avoiding 0.14.x because it depends on nightly features.
