### PR TITLE
Add Repo.put_loose_object() method.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,12 @@ version = "0.1.0"
 authors = ["Eric Scouten <eric@scouten.com>"]
 edition = "2018"
 
+# We use the C-language version of zlib for now because the Rust implementation
+# doesn't match git's implementation byte-for-byte. Possible we could swap out
+# implementations later, but not for now.
+
 [dependencies]
+flate2 = { version = "1.0", features = ["zlib"], default-features = false }
 sha-1 = "0.9.0"
 tempfile = "3.1.0"
 thiserror = "1.0.20"

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -28,7 +28,7 @@ pub use on_disk::OnDisk;
 
 pub trait Repo {
     /// Writes a loose object to the repository.
-    /// 
+    ///
     /// This is analogous to `git hash-object -w`.
     fn put_loose_object(&mut self, object: &Object) -> Result<()>;
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -28,5 +28,7 @@ pub use on_disk::OnDisk;
 
 pub trait Repo {
     /// Writes a loose object to the repository.
+    /// 
+    /// This is analogous to `git hash-object -w`.
     fn put_loose_object(&mut self, object: &Object) -> Result<()>;
 }

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -7,6 +7,8 @@
 //! (see `rsgit::repo::on_disk`), you could envision repositories stored entirely
 //! in memory, or on a remote file system or database.
 
+use crate::object::Object;
+
 mod error;
 pub use error::{Error, Result};
 
@@ -24,4 +26,7 @@ pub use on_disk::OnDisk;
 /// The provided methods on this trait represent the common "porcelain" and "plumbing"
 /// operations for a git repo, regardless of its storage mechanism.
 
-pub trait Repo {}
+pub trait Repo {
+    /// Writes a loose object to the repository.
+    fn put_loose_object(&mut self, object: &Object) -> Result<()>;
+}

--- a/src/repo/on_disk/tests/mod.rs
+++ b/src/repo/on_disk/tests/mod.rs
@@ -1,1 +1,2 @@
 mod new;
+mod put_loose_object;

--- a/src/repo/on_disk/tests/put_loose_object.rs
+++ b/src/repo/on_disk/tests/put_loose_object.rs
@@ -1,0 +1,107 @@
+use std::io::Write;
+
+use super::super::*;
+
+use crate::object::{Kind, Object};
+use crate::test_support::TempGitRepo;
+
+extern crate dir_diff;
+extern crate tempfile;
+
+use tempfile::{tempdir, NamedTempFile};
+
+const TEST_CONTENT: &[u8; 13] = b"test content\n";
+
+#[test]
+fn matches_command_line_git() {
+    let mut test_file = NamedTempFile::new().unwrap();
+    test_file.write_all(TEST_CONTENT).unwrap();
+
+    let mut tgr = TempGitRepo::new();
+    let output = tgr
+        .command("git")
+        .args(&["hash-object", "-w", test_file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let expected_output = b"d670460b4b4aece5915caf5c68d12f560a9fe3e4\n".to_vec();
+
+    assert!(output.status.success());
+    assert_eq!(output.stdout, expected_output);
+
+    let rsgit_temp = tempdir().unwrap();
+    let r_path = rsgit_temp.path();
+    let mut r = OnDisk::init(r_path).unwrap();
+
+    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    r.put_loose_object(&o).unwrap();
+
+    assert_eq!(dir_diff::is_different(tgr.path(), r_path).unwrap(), false);
+}
+
+#[test]
+fn matches_command_line_git_large_file() {
+    let mut test_file = NamedTempFile::new().unwrap();
+    let test_content = "foobar".repeat(1000);
+    let test_content = test_content.as_bytes();
+    test_file.write_all(&test_content).unwrap();
+
+    let mut tgr = TempGitRepo::new();
+    let output = tgr
+        .command("git")
+        .args(&["hash-object", "-w", test_file.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let mut object_id = String::from_utf8(output.stdout).unwrap();
+    object_id.truncate(40);
+
+    let rsgit_temp = tempdir().unwrap();
+    let r_path = rsgit_temp.path();
+    let mut r = OnDisk::init(r_path).unwrap();
+
+    let o = Object::new(Kind::Blob, Box::new(test_content.to_vec())).unwrap();
+    assert_eq!(object_id, o.id().to_string());
+    r.put_loose_object(&o).unwrap();
+
+    assert_eq!(dir_diff::is_different(tgr.path(), r_path).unwrap(), false);
+}
+
+#[test]
+fn error_cant_create_objects_dir() {
+    let rsgit_temp = tempdir().unwrap();
+    let r_path = rsgit_temp.path();
+    let mut r = OnDisk::init(r_path).unwrap();
+
+    let objects_dir = r_path.join(".git/objects/d6");
+    fs::write(&objects_dir, "sand in the gears").unwrap();
+
+    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    let err = r.put_loose_object(&o).unwrap_err();
+
+    match err {
+        Error::IoError(err) => assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists),
+        _ => panic!("Unexpected error {:?}", err),
+    }
+}
+
+#[test]
+fn error_object_exists() {
+    let rsgit_temp = tempdir().unwrap();
+    let r_path = rsgit_temp.path();
+    let mut r = OnDisk::init(r_path).unwrap();
+
+    let mut object_path = r_path.join(".git/objects/d6");
+    fs::create_dir(&object_path).unwrap();
+
+    object_path.push("70460b4b4aece5915caf5c68d12f560a9fe3e4");
+    fs::write(&object_path, "sand in the gears").unwrap();
+
+    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    let err = r.put_loose_object(&o).unwrap_err();
+
+    match err {
+        Error::IoError(err) => assert_eq!(err.kind(), std::io::ErrorKind::AlreadyExists),
+        _ => panic!("Unexpected error {:?}", err),
+    }
+}


### PR DESCRIPTION
## Changes in This Pull Request
This is analogous to `git hash-object -w`.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
