### PR TITLE
Change type of cli::Result type to be parameterized on result type.

### DIFF
--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -17,7 +17,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
         )
 }
 
-pub(crate) fn run(cli: &mut Cli, init_matches: &ArgMatches) -> Result {
+pub(crate) fn run(cli: &mut Cli, init_matches: &ArgMatches) -> Result<()> {
     let dir = init_matches.value_of("directory").unwrap();
 
     let path = Path::new(dir);

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -18,7 +18,7 @@ pub(crate) fn app<'a, 'b>() -> App<'a, 'b> {
         .subcommand(init::subcommand())
 }
 
-pub(crate) type Result = std::result::Result<(), Box<dyn Error>>;
+pub(crate) type Result<T> = std::result::Result<T, Box<dyn Error>>;
 
 pub(crate) struct Cli<'a> {
     pub arg_matches: ArgMatches<'a>,
@@ -27,7 +27,7 @@ pub(crate) struct Cli<'a> {
 }
 
 impl<'a> Cli<'a> {
-    pub fn run(&mut self) -> Result {
+    pub fn run(&mut self) -> Result<()> {
         let matches = self.arg_matches.clone();
         // ^^ Ugh. Need an independent copy of matches so we can still pass
         // the Cli struct through to subcommand imps.


### PR DESCRIPTION
This gives us more flexibility to use it in subcommand implementations.
