### PR TITLE
Avoid use of "out" parameter in parse_utils::read_line.

### DIFF
--- a/src/object/check_commit.rs
+++ b/src/object/check_commit.rs
@@ -57,6 +57,18 @@ mod tests {
     use super::*;
 
     #[test]
+    fn invalid_empty() {
+        let cs = "".to_string();
+        assert_eq!(commit_is_valid(&cs).unwrap(), false);
+    }
+
+    #[test]
+    fn invalid_only_tree() {
+        let cs = "tree be9bfa841874ccc9f2ef7c48d0c76226f89b7189\n".to_string();
+        assert_eq!(commit_is_valid(&cs).unwrap(), false);
+    }
+
+    #[test]
     fn valid_no_parent() {
         let cs = "tree be9bfa841874ccc9f2ef7c48d0c76226f89b7189\n\
                   author A. U. Thor <author@localhost> 1 +0000\n\

--- a/src/object/check_commit.rs
+++ b/src/object/check_commit.rs
@@ -2,27 +2,32 @@ use super::{parse_utils, ContentSource, ContentSourceResult};
 
 pub(crate) fn commit_is_valid(s: &dyn ContentSource) -> ContentSourceResult<bool> {
     let mut r = s.open()?;
-    let mut line = Vec::new();
 
-    parse_utils::read_line(&mut r, &mut line)?;
-    if let Some(tree_id) = parse_utils::header(&line.as_slice(), b"tree") {
-        if !parse_utils::object_id_is_valid(&tree_id) {
+    if let Some(line) = parse_utils::read_line(&mut r)? {
+        if let Some(tree_id) = parse_utils::header(&line.as_slice(), b"tree") {
+            if !parse_utils::object_id_is_valid(&tree_id) {
+                return Ok(false);
+            }
+        } else {
             return Ok(false);
         }
     } else {
         return Ok(false);
     }
 
-    loop {
-        parse_utils::read_line(&mut r, &mut line)?;
-        if let Some(parent_id) = parse_utils::header(&line.as_slice(), b"parent") {
-            if !parse_utils::object_id_is_valid(&parent_id) {
-                return Ok(false);
+    let line = loop {
+        if let Some(line) = parse_utils::read_line(&mut r)? {
+            if let Some(parent_id) = parse_utils::header(&line.as_slice(), b"parent") {
+                if !parse_utils::object_id_is_valid(&parent_id) {
+                    return Ok(false);
+                }
+            } else {
+                break line;
             }
         } else {
-            break;
+            return Ok(false);
         }
-    }
+    };
 
     if let Some(_author) = parse_utils::header(&line.as_slice(), b"author") {
         if !parse_utils::attribution_is_valid(&line) {
@@ -32,9 +37,12 @@ pub(crate) fn commit_is_valid(s: &dyn ContentSource) -> ContentSourceResult<bool
         return Ok(false);
     }
 
-    parse_utils::read_line(&mut r, &mut line)?;
-    if let Some(_committer) = parse_utils::header(&line.as_slice(), b"committer") {
-        if !parse_utils::attribution_is_valid(&line) {
+    if let Some(line) = parse_utils::read_line(&mut r)? {
+        if let Some(_committer) = parse_utils::header(&line.as_slice(), b"committer") {
+            if !parse_utils::attribution_is_valid(&line) {
+                return Ok(false);
+            }
+        } else {
             return Ok(false);
         }
     } else {


### PR DESCRIPTION
Also remove irrelevant dead-code warning suppression. (Fixes #47.)
