### PR TITLE
Standarize format of `use` clauses to the following sequence:

### DIFF
--- a/src/cli/find_repo.rs
+++ b/src/cli/find_repo.rs
@@ -1,5 +1,4 @@
-use std::env;
-use std::path::Path;
+use std::{env, path::Path};
 
 use rsgit::repo::{OnDisk, Result};
 
@@ -50,9 +49,9 @@ pub fn from_current_dir() -> Result<OnDisk> {
 mod tests {
     use super::*;
 
-    use rsgit::repo::Error;
-
     use crate::test_support::TempGitRepo;
+
+    use rsgit::repo::Error;
 
     #[test]
     fn simple_case() {

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -1,11 +1,9 @@
-use std::io::Write;
-use std::path::Path;
+use std::{io::Write, path::Path};
 
 use super::{Cli, Result};
 
-use rsgit::repo::OnDisk;
-
 use clap::{App, Arg, ArgMatches, SubCommand};
+use rsgit::repo::OnDisk;
 
 pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("init")
@@ -34,8 +32,7 @@ pub(crate) fn run(cli: &mut Cli, init_matches: &ArgMatches) -> Result<()> {
 
 #[cfg(test)]
 mod tests {
-    use crate::cli::Cli;
-    use crate::test_support::TempGitRepo;
+    use crate::{cli::Cli, test_support::TempGitRepo};
 
     #[test]
     fn matches_command_line_git() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,11 +1,12 @@
 #![deny(warnings)]
 
-use std::error::Error;
+use std::{
+    error::Error,
+    io::{Read, Write},
+};
 
 #[cfg(test)]
 use std::ffi::OsString;
-
-use std::io::{Read, Write};
 
 use clap::{crate_version, App, AppSettings, ArgMatches};
 

--- a/src/object/attribution.rs
+++ b/src/object/attribution.rs
@@ -1,8 +1,10 @@
-use std::fmt;
-use std::str::{self, FromStr};
-use std::string::String;
+use std::{
+    fmt,
+    str::{self, FromStr},
+    string::String,
+};
 
-use super::parse_utils::split_once;
+use crate::object::parse_utils::split_once;
 
 /// An `Attribution` combines a person's identity (name and e-mail address)
 /// with the timestamp for a particular action.

--- a/src/object/check_commit.rs
+++ b/src/object/check_commit.rs
@@ -1,4 +1,4 @@
-use super::{parse_utils, ContentSource, ContentSourceResult};
+use crate::object::{parse_utils, ContentSource, ContentSourceResult};
 
 pub(crate) fn commit_is_valid(s: &dyn ContentSource) -> ContentSourceResult<bool> {
     let mut r = s.open()?;

--- a/src/object/check_tree.rs
+++ b/src/object/check_tree.rs
@@ -1,10 +1,9 @@
-use super::{parse_utils, ContentSource, ContentSourceResult};
+use std::{cmp::Ordering, collections::HashSet, io::BufRead};
 
-use crate::path::{CheckPlatforms, FileMode, PathMode, PathSegment};
-
-use std::cmp::Ordering;
-use std::collections::HashSet;
-use std::io::BufRead;
+use crate::{
+    object::{parse_utils, ContentSource, ContentSourceResult},
+    path::{CheckPlatforms, FileMode, PathMode, PathSegment},
+};
 
 use unicode_normalization::UnicodeNormalization;
 

--- a/src/object/content_source.rs
+++ b/src/object/content_source.rs
@@ -1,5 +1,7 @@
-use std::io::{BufRead, Cursor};
-use std::vec::Vec;
+use std::{
+    io::{BufRead, Cursor},
+    vec::Vec,
+};
 
 /// Result type for operations which depend on [`ContentSource.open()`].
 /// Since [`ContentSource`] may wrap arbitrary sources,

--- a/src/object/file_content_source.rs
+++ b/src/object/file_content_source.rs
@@ -1,9 +1,11 @@
-use std::convert::AsRef;
-use std::fs::{self, File};
-use std::io::{self, BufReader, Error, ErrorKind};
-use std::path::{Path, PathBuf};
+use std::{
+    convert::AsRef,
+    fs::{self, File},
+    io::{self, BufReader, Error, ErrorKind},
+    path::{Path, PathBuf},
+};
 
-use super::{ContentSource, ContentSourceOpenResult};
+use crate::object::{ContentSource, ContentSourceOpenResult};
 
 /// Implements [`ContentSource`] to read content from a file on disk.
 ///
@@ -42,9 +44,9 @@ impl ContentSource for FileContentSource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::{ErrorKind, Write};
+
+    use super::*;
 
     use tempfile::TempDir;
 

--- a/src/object/id.rs
+++ b/src/object/id.rs
@@ -1,5 +1,7 @@
-use std::fmt::{self, Write};
-use std::str::FromStr;
+use std::{
+    fmt::{self, Write},
+    str::FromStr,
+};
 
 use thiserror::Error;
 

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,9 +1,9 @@
 //! Represents the git concept of an "object" which is a tuple of
 //! object type and binary data identified by the hash of the binary data.
 
-use sha1::{Digest, Sha1};
-
 use crate::path::CheckPlatforms;
+
+use sha1::{Digest, Sha1};
 
 mod attribution;
 pub use attribution::Attribution;
@@ -147,11 +147,9 @@ fn assign_id(kind: Kind, content_source: &dyn ContentSource) -> ContentSourceRes
 
 #[cfg(test)]
 mod tests {
-    use super::*;
+    use std::{fs::File, io::Write, process::Command};
 
-    use std::fs::File;
-    use std::io::Write;
-    use std::process::Command;
+    use super::*;
 
     use tempfile::TempDir;
 

--- a/src/object/parse_utils.rs
+++ b/src/object/parse_utils.rs
@@ -118,9 +118,9 @@ pub(crate) fn split_once<'a>(s: &'a [u8], c: &u8) -> (&'a [u8], &'a [u8]) {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::Cursor;
+
+    use super::*;
 
     #[test]
     fn read_line_fn() {

--- a/src/object/read_content_source.rs
+++ b/src/object/read_content_source.rs
@@ -1,6 +1,6 @@
 use std::io::{self, Cursor, Error, ErrorKind, Read};
 
-use super::{ContentSource, ContentSourceOpenResult};
+use crate::object::{ContentSource, ContentSourceOpenResult};
 
 /// Implements [`ContentSource`] to read content from
 /// an arbitrary [`Read`] struct (often `stdin`).
@@ -53,9 +53,9 @@ impl ContentSource for ReadContentSource {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     use std::io::{Cursor, Result};
+
+    use super::*;
 
     #[test]
     fn happy_path() {

--- a/src/path/path_mode.rs
+++ b/src/path/path_mode.rs
@@ -1,6 +1,6 @@
 use std::cmp::{self, Ordering};
 
-use super::FileMode;
+use crate::path::FileMode;
 
 /// Represents the tuple of git path (an uninterpreted sequence of bytes,
 /// not necessarily UTF-8) and git file mode. Used for sorting trees of objects.

--- a/src/repo/on_disk/mod.rs
+++ b/src/repo/on_disk/mod.rs
@@ -7,16 +7,17 @@
 //! That said, it does intentionally use the same `.git` folder format as
 //! command-line git so that results may be compared for similar operations.
 
-use std::fs::{self, OpenOptions};
-use std::io::{self, Write};
-use std::path::{Path, PathBuf};
-
-use crate::object::Object;
+use std::{
+    fs::{self, OpenOptions},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
 
 use super::{Error, Repo, Result};
 
-use flate2::write::ZlibEncoder;
-use flate2::Compression;
+use crate::object::Object;
+
+use flate2::{write::ZlibEncoder, Compression};
 
 /// Implementation of [`Repo`] that stores content on the local file system.
 ///

--- a/src/repo/on_disk/tests/new.rs
+++ b/src/repo/on_disk/tests/new.rs
@@ -1,6 +1,6 @@
-use super::super::*;
-
 use std::fs;
+
+use super::super::*;
 
 use crate::test_support::TempGitRepo;
 

--- a/src/repo/on_disk/tests/put_loose_object.rs
+++ b/src/repo/on_disk/tests/put_loose_object.rs
@@ -2,8 +2,10 @@ use std::io::Write;
 
 use super::super::*;
 
-use crate::object::{Kind, Object};
-use crate::test_support::TempGitRepo;
+use crate::{
+    object::{Kind, Object},
+    test_support::TempGitRepo,
+};
 
 use tempfile::{tempdir, NamedTempFile};
 

--- a/src/test_support/temp_cwd.rs
+++ b/src/test_support/temp_cwd.rs
@@ -1,5 +1,7 @@
-use std::env;
-use std::path::{Path, PathBuf};
+use std::{
+    env,
+    path::{Path, PathBuf},
+};
 
 // A TempCwd allows you to temporarily change the current
 // working directory for the host process.
@@ -37,9 +39,9 @@ impl Drop for TempCwd {
 
 #[cfg(test)]
 mod tests {
-    use super::TempCwd;
-
     use std::env;
+
+    use super::TempCwd;
 
     #[test]
     fn temp_cwd() {

--- a/src/test_support/temp_git_repo.rs
+++ b/src/test_support/temp_git_repo.rs
@@ -1,7 +1,9 @@
-use std::ffi::OsStr;
-use std::fs;
-use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::{
+    ffi::OsStr,
+    fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
 
 // A TempGitRepo creates a temporary, empty repo using
 // the command-line git from the host system. This is often

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,7 +1,4 @@
-use std::env::set_current_dir;
-use std::ffi::OsStr;
-use std::fs;
-use std::path::Path;
+use std::{env::set_current_dir, ffi::OsStr, fs, path::Path};
 
 use assert_cmd::cargo;
 

--- a/tests/t0000_basic.rs
+++ b/tests/t0000_basic.rs
@@ -1,5 +1,4 @@
-use std::fs;
-use std::process::Command;
+use std::{fs, process::Command};
 
 mod common;
 


### PR DESCRIPTION
1. Built-in modules (`use std::...`). If compiling without `std`, treat the built-in modules (`alloc`, etc.) equivalently and list them in alphabetical order.
2. Parent modules (`use super::*`). This line should usually appear at the top of any test module.
3. Modules from elsewhere in this crate (`use crate::...`). Except as noted above for test modules, `crate`-relative references are preferred over `super` references.
4. Modules from third-party crates (`use serde::...`). Crates should be listed in alphabetical order.
5. Child modules (`mod ...`). These should be listed in alphabetical order, one module per line. If any child modules are re-exported, any such re-exports should immediately follow the `mod` statement.
