### PR TITLE
CLI: Implement `hash-object` subcommand.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ assert_cmd = "1.0"
 clap = "2.33"
 dir-diff = "0.3.2"
 predicates = "1"
+serial_test = "0.5.0"
 
 [features]
 default = ["clap"]

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -1,9 +1,9 @@
-// use std::io::Write;
-// use std::path::Path;
+use std::error::Error;
 
-use super::{Cli, Result, find_repo};
+use super::{find_repo, Cli};
 
 // use rsgit::repo::OnDisk;
+use rsgit::object::Object;
 
 use clap::{App, Arg, ArgMatches, SubCommand};
 
@@ -13,6 +13,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
         .arg(
             Arg::with_name("t")
                 .short("t")
+                .value_name("type")
                 .help("Specify the type (default 'blob')"),
         )
         .arg(
@@ -20,11 +21,18 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
                 .short("w")
                 .help("Actually write the object into the object database"),
         )
-        .arg(Arg::with_name("literally").help("Bypass validity checks"))
+        .arg(
+            Arg::with_name("literally")
+                .long("literally")
+                .help("Bypass validity checks"),
+        )
+        .arg(Arg::with_name("file").required(true))
 }
 
-pub(crate) fn run(_cli: &mut Cli, _init_matches: &ArgMatches) -> Result {
+pub(crate) fn run(_cli: &mut Cli, args: &ArgMatches) -> super::Result {
     let _repo = find_repo::from_current_dir()?;
+
+    let _object = object_from_args(&args)?;
 
     // TO DO: Parse cmd-line opts.
 
@@ -32,6 +40,12 @@ pub(crate) fn run(_cli: &mut Cli, _init_matches: &ArgMatches) -> Result {
 
     Ok(())
 }
+
+fn object_from_args(args: &ArgMatches) -> Result<Object, Box<dyn Error>> {
+    let type = type_from_args(args: &ArgMatches)
+}
+
+fn type_from_args(args: &ArgMatches) ->
 
 // #[cfg(test)]
 // mod tests {

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -71,11 +71,17 @@ fn type_from_args(args: &ArgMatches) -> Result<Kind> {
             "commit" => Ok(Kind::Commit),
             "tag" => Ok(Kind::Tag),
             "tree" => Ok(Kind::Tree),
-            _ => Err(Box::new(Error {
-                message: "-t must be one of blob, commit, tag, or tree".to_string(),
-                kind: ErrorKind::InvalidValue,
-                info: None,
-            })),
+            other => {
+                if args.is_present("literally") {
+                    Ok(Kind::Other(other.as_bytes().to_owned()))
+                } else {
+                    Err(Box::new(Error {
+                        message: "-t must be one of blob, commit, tag, or tree".to_string(),
+                        kind: ErrorKind::InvalidValue,
+                        info: None,
+                    }))
+                }
+            }
         },
         None => Ok(Kind::Blob),
     }

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -1,6 +1,9 @@
+use std::io::Write;
+
 use super::{find_repo, Cli, Result};
 
 use rsgit::object::{FileContentSource, Kind, Object};
+use rsgit::repo::Repo;
 
 use clap::{App, Arg, ArgMatches, Error, ErrorKind, SubCommand};
 
@@ -26,8 +29,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
         .arg(Arg::with_name("file").required(true))
 }
 
-pub(crate) fn run(_cli: &mut Cli, args: &ArgMatches) -> Result<()> {
-    let _repo = find_repo::from_current_dir()?;
+pub(crate) fn run(cli: &mut Cli, args: &ArgMatches) -> Result<()> {
     let object = object_from_args(&args)?;
 
     if !args.is_present("literally") && !object.is_valid()? {
@@ -38,9 +40,12 @@ pub(crate) fn run(_cli: &mut Cli, args: &ArgMatches) -> Result<()> {
         }));
     }
 
-    // TO DO: Write object to repo (if -w).
+    if args.is_present("w") {
+        let mut repo = find_repo::from_current_dir()?;
+        repo.put_loose_object(&object)?;
+    }
 
-    // TO DO: Write object ID.
+    writeln!(cli, "{}", object.id())?;
 
     Ok(())
 }

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -107,6 +107,7 @@ mod tests {
     use crate::cli::Cli;
     use crate::test_support::{TempCwd, TempGitRepo};
 
+    use serial_test::serial;
     use tempfile::TempDir;
 
     #[test]
@@ -147,6 +148,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn matches_command_line_git() {
         let stdin: Vec<u8> = b"test content\n".to_vec();
 
@@ -180,6 +182,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn err_corrupt_commit() {
         let stdin: Vec<u8> = b"test content\n".to_vec();
 
@@ -202,6 +205,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn err_corrupt_tree() {
         let stdin: Vec<u8> = b"test content\n".to_vec();
 
@@ -222,6 +226,7 @@ mod tests {
     }
 
     #[test]
+    #[serial]
     fn err_corrupt_tag() {
         let stdin: Vec<u8> = b"test content\n".to_vec();
 

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -100,12 +100,16 @@ fn content_source_from_args(cli: &mut Cli, args: &ArgMatches) -> Result<Box<dyn 
 
 #[cfg(test)]
 mod tests {
-    use std::fs::File;
-    use std::io::Write;
-    use std::process::{Command, Stdio};
+    use std::{
+        fs::File,
+        io::Write,
+        process::{Command, Stdio},
+    };
 
-    use crate::cli::Cli;
-    use crate::test_support::{TempCwd, TempGitRepo};
+    use crate::{
+        cli::Cli,
+        test_support::{TempCwd, TempGitRepo},
+    };
 
     use serial_test::serial;
     use tempfile::TempDir;

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -179,6 +179,28 @@ mod tests {
         assert!(!dir_diff::is_different(c_path, r_path).unwrap());
     }
 
+    #[test]
+    fn err_corrupt_commit() {
+        let stdin: Vec<u8> = b"test content\n".to_vec();
+
+        let c_tgr = TempGitRepo::new();
+        let c_path = c_tgr.path();
+
+        let r_tgr = TempGitRepo::new();
+        let r_path = r_tgr.path();
+
+        let _r_cwd = TempCwd::new(r_path);
+        let r_err = Cli::run_with_stdin_and_args(
+            stdin,
+            vec!["hash-object", "-t", "commit", "-w", "--stdin"],
+        )
+        .unwrap_err();
+
+        assert_eq!(r_err.to_string(), "corrupt commit\n");
+
+        assert!(!dir_diff::is_different(c_path, r_path).unwrap());
+    }
+
     //     #[test]
     //     fn error_no_dir() {
     //         let err = Cli::run_with_args(vec!["init"]).unwrap_err();

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -154,6 +154,7 @@ mod tests {
         let mut cgit = Command::new("git")
             .current_dir(c_path)
             .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
             .args(&["hash-object", "-w", "--stdin"])
             .spawn()
             .unwrap();
@@ -164,7 +165,6 @@ mod tests {
         }
 
         let c_stdout = cgit.wait_with_output().unwrap().stdout;
-
         let r_tgr = TempGitRepo::new();
         let r_path = r_tgr.path();
 
@@ -173,8 +173,6 @@ mod tests {
             Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "-w", "--stdin"]).unwrap();
 
         assert_eq!(c_stdout, r_stdout);
-        // This assetion is failing in a way that suggests we aren't
-        // actually feeding stdin as expected to C git.
 
         assert!(!dir_diff::is_different(c_path, r_path).unwrap());
     }

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -28,9 +28,15 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
 
 pub(crate) fn run(_cli: &mut Cli, args: &ArgMatches) -> Result<()> {
     let _repo = find_repo::from_current_dir()?;
-    let _object = object_from_args(&args)?;
+    let object = object_from_args(&args)?;
 
-    // TO DO: Check validity of object (if not --literally).
+    if !args.is_present("literally") && !object.is_valid()? {
+        return Err(Box::new(Error {
+            message: format!("corrupt {}", args.value_of("t").unwrap()),
+            kind: ErrorKind::InvalidValue,
+            info: None,
+        }));
+    }
 
     // TO DO: Write object to repo (if -w).
 

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -103,7 +103,7 @@ mod tests {
     use std::process::{Command, Stdio};
 
     use crate::cli::Cli;
-    use crate::test_support::TempGitRepo;
+    use crate::test_support::{TempCwd, TempGitRepo};
 
     use tempfile::TempDir;
 
@@ -168,12 +168,13 @@ mod tests {
         let r_tgr = TempGitRepo::new();
         let r_path = r_tgr.path();
 
-        // STOP: Need to temporarily change CWD for this to work
-        // as intended. We'll be back.
+        let _r_cwd = TempCwd::new(r_path);
         let r_stdout =
             Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "-w", "--stdin"]).unwrap();
 
         assert_eq!(c_stdout, r_stdout);
+        // This assetion is failing in a way that suggests we aren't
+        // actually feeding stdin as expected to C git.
 
         assert!(!dir_diff::is_different(c_path, r_path).unwrap());
     }

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -201,6 +201,46 @@ mod tests {
         assert!(!dir_diff::is_different(c_path, r_path).unwrap());
     }
 
+    #[test]
+    fn err_corrupt_tree() {
+        let stdin: Vec<u8> = b"test content\n".to_vec();
+
+        let c_tgr = TempGitRepo::new();
+        let c_path = c_tgr.path();
+
+        let r_tgr = TempGitRepo::new();
+        let r_path = r_tgr.path();
+
+        let _r_cwd = TempCwd::new(r_path);
+        let r_err =
+            Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "-t", "tree", "-w", "--stdin"])
+                .unwrap_err();
+
+        assert_eq!(r_err.to_string(), "corrupt tree\n");
+
+        assert!(!dir_diff::is_different(c_path, r_path).unwrap());
+    }
+
+    #[test]
+    fn err_corrupt_tag() {
+        let stdin: Vec<u8> = b"test content\n".to_vec();
+
+        let c_tgr = TempGitRepo::new();
+        let c_path = c_tgr.path();
+
+        let r_tgr = TempGitRepo::new();
+        let r_path = r_tgr.path();
+
+        let _r_cwd = TempCwd::new(r_path);
+        let r_err =
+            Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "-t", "tag", "-w", "--stdin"])
+                .unwrap_err();
+
+        assert_eq!(r_err.to_string(), "corrupt tag\n");
+
+        assert!(!dir_diff::is_different(c_path, r_path).unwrap());
+    }
+
     //     #[test]
     //     fn error_no_dir() {
     //         let err = Cli::run_with_args(vec!["init"]).unwrap_err();

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -1,0 +1,80 @@
+// use std::io::Write;
+// use std::path::Path;
+
+use super::{Cli, Result};
+
+// use rsgit::repo::OnDisk;
+
+use clap::{App, Arg, ArgMatches, SubCommand};
+
+pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
+    SubCommand::with_name("hash-object")
+        .about("Compute object ID and optionally creates a blob from a file")
+        .arg(
+            Arg::with_name("t")
+                .short("t")
+                .help("Specify the type (default 'blob')"),
+        )
+        .arg(
+            Arg::with_name("w")
+                .short("w")
+                .help("Actually write the object into the object database"),
+        )
+        .arg(Arg::with_name("literally").help("Bypass validity checks"))
+}
+
+pub(crate) fn run(cli: &mut Cli, init_matches: &ArgMatches) -> Result {
+    // TO DO: On-disk repo discovery.
+
+    // TO DO: Parse cmd-line opts.
+
+    // TO DO: Hash the object, etc.
+
+    Ok(())
+}
+
+// #[cfg(test)]
+// mod tests {
+//     use crate::cli::Cli;
+//     use crate::test_support::TempGitRepo;
+
+//     #[test]
+//     fn matches_command_line_git() {
+//         let tgr = TempGitRepo::new();
+//         let c_path = tgr.path();
+
+//         let r_path = tempfile::tempdir().unwrap();
+//         let r_pathstr = r_path.path().to_str().unwrap();
+
+//         let stdout = Cli::run_with_args(vec!["init", &r_pathstr]).unwrap();
+
+//         let expected_std = format!("Initialized empty Git repository in {}\n", r_pathstr);
+
+//         assert_eq!(stdout, expected_std.as_bytes());
+//         assert!(!dir_diff::is_different(c_path, r_path.path()).unwrap());
+//     }
+
+//     #[test]
+//     fn error_no_dir() {
+//         let err = Cli::run_with_args(vec!["init"]).unwrap_err();
+
+//         let errmsg = err.to_string();
+//         assert!(
+//             errmsg.contains("required arguments were not provided"),
+//             "\nincorrect error message:\n\n{}",
+//             errmsg
+//         );
+//     }
+
+//     #[test]
+//     fn error_too_many_args() {
+//         let err = Cli::run_with_args(vec!["init", "here", "and there"]).unwrap_err();
+
+//         let errmsg = err.to_string();
+//         assert!(
+//             errmsg.contains("wasn't expected"),
+//             "\nincorrect error message:\n\n{}",
+//             errmsg
+//         );
+//     }
+// }

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -1,7 +1,7 @@
 // use std::io::Write;
 // use std::path::Path;
 
-use super::{Cli, Result};
+use super::{Cli, Result, find_repo};
 
 // use rsgit::repo::OnDisk;
 
@@ -24,7 +24,7 @@ pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
 }
 
 pub(crate) fn run(_cli: &mut Cli, _init_matches: &ArgMatches) -> Result {
-    // TO DO: On-disk repo discovery.
+    let _repo = find_repo::from_current_dir()?;
 
     // TO DO: Parse cmd-line opts.
 

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -250,6 +250,27 @@ mod tests {
         assert!(!dir_diff::is_different(c_path, r_path).unwrap());
     }
 
+    #[test]
+    #[serial]
+    fn err_invalid_object_type() {
+        let stdin: Vec<u8> = b"test content\n".to_vec();
+
+        let c_tgr = TempGitRepo::new();
+        let c_path = c_tgr.path();
+
+        let r_tgr = TempGitRepo::new();
+        let r_path = r_tgr.path();
+
+        let _r_cwd = TempCwd::new(r_path);
+        let r_err =
+            Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "-t", "bogus", "-w", "--stdin"])
+                .unwrap_err();
+
+        assert_eq!(r_err.to_string(), "-t must be one of blob, commit, tag, or tree\n");
+
+        assert!(!dir_diff::is_different(c_path, r_path).unwrap());
+    }
+
     //     #[test]
     //     fn error_no_dir() {
     //         let err = Cli::run_with_args(vec!["init"]).unwrap_err();

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -60,7 +60,7 @@ pub(crate) fn run(cli: &mut Cli, args: &ArgMatches) -> Result<()> {
 fn object_from_args(cli: &mut Cli, args: &ArgMatches) -> Result<Object> {
     let kind = type_from_args(&args)?;
     let content_source = content_source_from_args(cli, &args)?;
-    let object = Object::new(kind, content_source)?;
+    let object = Object::new(&kind, content_source)?;
     Ok(object)
 }
 

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -2,10 +2,12 @@ use std::io::Write;
 
 use super::{find_repo, Cli, Result};
 
-use rsgit::object::{ContentSource, FileContentSource, Kind, Object, ReadContentSource};
-use rsgit::repo::Repo;
-
 use clap::{App, Arg, ArgMatches, Error, ErrorKind, SubCommand};
+
+use rsgit::{
+    object::{ContentSource, FileContentSource, Kind, Object, ReadContentSource},
+    repo::Repo,
+};
 
 pub(crate) fn subcommand<'a, 'b>() -> App<'a, 'b> {
     SubCommand::with_name("hash-object")

--- a/src/cli/hash_object.rs
+++ b/src/cli/hash_object.rs
@@ -96,48 +96,60 @@ fn content_source_from_args(cli: &mut Cli, args: &ArgMatches) -> Result<Box<dyn 
     }
 }
 
-// #[cfg(test)]
-// mod tests {
-//     use crate::cli::Cli;
-//     use crate::test_support::TempGitRepo;
+#[cfg(test)]
+mod tests {
+    use crate::cli::Cli;
+    // use crate::test_support::TempGitRepo;
 
-//     #[test]
-//     fn matches_command_line_git() {
-//         let tgr = TempGitRepo::new();
-//         let c_path = tgr.path();
+    #[test]
+    fn hash_with_no_repo() {
+        // $ echo 'test content' | git hash-object --stdin
+        // d670460b4b4aece5915caf5c68d12f560a9fe3e4
 
-//         let r_path = tempfile::tempdir().unwrap();
-//         let r_pathstr = r_path.path().to_str().unwrap();
+        let stdin: Vec<u8> = b"test content\n".to_vec();
+        let stdout = Cli::run_with_stdin_and_args(stdin, vec!["hash-object", "--stdin"]).unwrap();
 
-//         let stdout = Cli::run_with_args(vec!["init", &r_pathstr]).unwrap();
+        let expected_stdout = "d670460b4b4aece5915caf5c68d12f560a9fe3e4\n";
+        assert_eq!(stdout, expected_stdout.as_bytes());
+    }
 
-//         let expected_std = format!("Initialized empty Git repository in {}\n", r_pathstr);
+    //     #[test]
+    //     fn matches_command_line_git() {
+    //         let tgr = TempGitRepo::new();
+    //         let c_path = tgr.path();
 
-//         assert_eq!(stdout, expected_std.as_bytes());
-//         assert!(!dir_diff::is_different(c_path, r_path.path()).unwrap());
-//     }
+    //         let r_path = tempfile::tempdir().unwrap();
+    //         let r_pathstr = r_path.path().to_str().unwrap();
 
-//     #[test]
-//     fn error_no_dir() {
-//         let err = Cli::run_with_args(vec!["init"]).unwrap_err();
+    //         let stdout = Cli::run_with_args(vec!["init", &r_pathstr]).unwrap();
 
-//         let errmsg = err.to_string();
-//         assert!(
-//             errmsg.contains("required arguments were not provided"),
-//             "\nincorrect error message:\n\n{}",
-//             errmsg
-//         );
-//     }
+    //         let expected_std = format!("Initialized empty Git repository in {}\n", r_pathstr);
 
-//     #[test]
-//     fn error_too_many_args() {
-//         let err = Cli::run_with_args(vec!["init", "here", "and there"]).unwrap_err();
+    //         assert_eq!(stdout, expected_std.as_bytes());
+    //         assert!(!dir_diff::is_different(c_path, r_path.path()).unwrap());
+    //     }
 
-//         let errmsg = err.to_string();
-//         assert!(
-//             errmsg.contains("wasn't expected"),
-//             "\nincorrect error message:\n\n{}",
-//             errmsg
-//         );
-//     }
-// }
+    //     #[test]
+    //     fn error_no_dir() {
+    //         let err = Cli::run_with_args(vec!["init"]).unwrap_err();
+
+    //         let errmsg = err.to_string();
+    //         assert!(
+    //             errmsg.contains("required arguments were not provided"),
+    //             "\nincorrect error message:\n\n{}",
+    //             errmsg
+    //         );
+    //     }
+
+    //     #[test]
+    //     fn error_too_many_args() {
+    //         let err = Cli::run_with_args(vec!["init", "here", "and there"]).unwrap_err();
+
+    //         let errmsg = err.to_string();
+    //         assert!(
+    //             errmsg.contains("wasn't expected"),
+    //             "\nincorrect error message:\n\n{}",
+    //             errmsg
+    //         );
+    //     }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -7,6 +7,7 @@ use std::io::{Read, Write};
 
 use clap::{crate_version, App, AppSettings, ArgMatches};
 
+mod hash_object;
 mod init;
 
 pub(crate) fn app<'a, 'b>() -> App<'a, 'b> {
@@ -14,6 +15,7 @@ pub(crate) fn app<'a, 'b>() -> App<'a, 'b> {
         .version(crate_version!())
         .setting(AppSettings::SubcommandRequiredElseHelp)
         .setting(AppSettings::VersionlessSubcommands)
+        .subcommand(hash_object::subcommand())
         .subcommand(init::subcommand())
 }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -44,7 +44,10 @@ impl<'a> Cli<'a> {
     }
 
     #[cfg(test)]
-    pub fn run_with_args<I, T>(args: I) -> std::result::Result<Vec<u8>, Box<dyn Error>>
+    pub fn run_with_stdin_and_args<I, T>(
+        stdin: Vec<u8>,
+        args: I,
+    ) -> std::result::Result<Vec<u8>, Box<dyn Error>>
     where
         I: IntoIterator<Item = T>,
         T: Into<OsString> + Clone,
@@ -52,7 +55,7 @@ impl<'a> Cli<'a> {
         let mut args: Vec<OsString> = args.into_iter().map(|x| x.into()).collect();
         args.insert(0, OsString::from("rsgit"));
 
-        let mut stdin = std::io::Cursor::new(Vec::new());
+        let mut stdin = std::io::Cursor::new(stdin);
         let mut stdout = Vec::new();
 
         Cli {
@@ -63,6 +66,16 @@ impl<'a> Cli<'a> {
         .run()?;
 
         Ok(stdout)
+    }
+
+    #[cfg(test)]
+    pub fn run_with_args<I, T>(args: I) -> std::result::Result<Vec<u8>, Box<dyn Error>>
+    where
+        I: IntoIterator<Item = T>,
+        T: Into<OsString> + Clone,
+    {
+        let stdin: Vec<u8> = Vec::new();
+        Cli::run_with_stdin_and_args(stdin, args)
     }
 }
 

--- a/src/object/read_content_source.rs
+++ b/src/object/read_content_source.rs
@@ -25,7 +25,7 @@ impl ReadContentSource {
     /// Create a `ReadContentSource` for an arbitrary [`Read`] struct.
     ///
     /// [`Read`]: https://doc.rust-lang.org/std/io/trait.Read.html
-    pub fn new<R: Read>(r: R) -> io::Result<ReadContentSource> {
+    pub fn new<R: Read>(r: &mut R) -> io::Result<ReadContentSource> {
         let mut content: Vec<u8> = Vec::new();
 
         let mut take = r.take(MAX_SIZE as u64 + 1);
@@ -60,7 +60,8 @@ mod tests {
     #[test]
     fn happy_path() {
         let tc: Vec<u8> = b"example".to_vec();
-        let rcs = ReadContentSource::new(Cursor::new(tc)).unwrap();
+        let mut c = Cursor::new(tc);
+        let rcs = ReadContentSource::new(&mut c).unwrap();
 
         assert_eq!(rcs.len(), 7);
 
@@ -88,8 +89,8 @@ mod tests {
 
     #[test]
     fn infinite_read_stream() {
-        let evil = InfiniteRead {};
-        let res = ReadContentSource::new(evil);
+        let mut evil = InfiniteRead {};
+        let res = ReadContentSource::new(&mut evil);
         assert!(res.is_err());
     }
 }

--- a/src/test_support/temp_cwd.rs
+++ b/src/test_support/temp_cwd.rs
@@ -8,12 +8,14 @@ use std::{
 //
 // When the struct goes out of scope, the current working
 // directory will be reset to its previous value.
-
+//
 // Because this struct is intended for testing, its functions
 // panic instead of returning Result structs.
-
+//
 // We override the dead_code warnings here because this
 // struct is only used in test code.
+//
+// Any test that uses this module should be marked #[serial].
 #[allow(dead_code)]
 pub(crate) struct TempCwd {
     old_path: PathBuf,

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -12,9 +12,13 @@ pub fn compare_git_and_rsgit(op: GitOp) {
     let c_dir = c_temp.path();
     sanitize_repo(c_dir);
 
+    println!("Running in C git ...");
+
     let cgit = OsStr::new("git");
     set_current_dir(c_dir).unwrap();
     op(&cgit, &c_dir);
+
+    println!("Running in rsgit ...");
 
     let r_temp = tempfile::tempdir().unwrap();
     let r_dir = r_temp.path();

--- a/tests/t1007_hash_object.rs
+++ b/tests/t1007_hash_object.rs
@@ -1,0 +1,504 @@
+use std::{
+    fs::File,
+    io::Write,
+    process::{Command, Stdio},
+};
+
+mod common;
+
+const HELLO_CONTENT: &[u8; 11] = b"Hello World";
+const HELLO_SHA1: &[u8; 40] = b"5e1c309dae7f45e0f39b1bf3ac3cd9db12e7d689";
+
+// --- Argument checking
+
+#[test]
+fn error_multiple_stdin_args() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let test_content: Vec<u8> = b"test content\n".to_vec();
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "--stdin", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(&test_content).unwrap();
+        }
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+// TODO: --stdin-paths option is not currently supported.
+// Add tests for that case if that is ever added.
+
+// TODO: --no-filters option is not currently supported.
+// Add tests for that case if that is ever added.
+
+// --- Behavior
+
+#[test]
+fn hash_file_without_writing() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let hello_path = path.join("hello");
+
+        {
+            let mut f = File::create(&hello_path).unwrap();
+            f.write_all(HELLO_CONTENT).unwrap();
+        }
+
+        let hello_path_str = hello_path.to_str().unwrap();
+
+        let output = Command::new(cmd)
+            .current_dir(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", hello_path_str])
+            .output()
+            .unwrap();
+
+        let mut expected_output = HELLO_SHA1.to_vec();
+        expected_output.push(10);
+
+        // TODO: Verify that blob does not exist.
+        // Needs implementation of cat-file.
+
+        assert_eq!(output.stdout, expected_output);
+    });
+}
+
+#[test]
+fn hash_file_without_writing_from_stdin() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(HELLO_CONTENT).unwrap();
+        }
+
+        let stdout = proc.wait_with_output().unwrap().stdout;
+
+        let mut expected_output = HELLO_SHA1.to_vec();
+        expected_output.push(10);
+
+        // TODO: Verify that blob does not exist.
+        // Needs implementation of cat-file.
+
+        assert_eq!(stdout, expected_output);
+    });
+}
+
+#[test]
+fn hash_file_and_write_to_database() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let hello_path = path.join("hello");
+
+        {
+            let mut f = File::create(&hello_path).unwrap();
+            f.write_all(HELLO_CONTENT).unwrap();
+        }
+
+        let hello_path_str = hello_path.to_str().unwrap();
+
+        let output = Command::new(cmd)
+            .current_dir(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-w", hello_path_str])
+            .output()
+            .unwrap();
+
+        let mut expected_output = HELLO_SHA1.to_vec();
+        expected_output.push(10);
+
+        // TODO: Verify that blob exists.
+        // Needs implementation of cat-file.
+
+        assert_eq!(output.stdout, expected_output);
+    });
+}
+
+// TODO: Add test cases for combinations of --stdin and file inputs.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for .gitattributes and CR/LF conversions.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for type filtering based on path.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for .gitattributes in subdirectories.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for type filtering in subdirectory.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for --no-filters option.
+// Not currently supported in rsgit.
+
+// TODO: Add test cases for --no-filters in combination with --stdin-paths option.
+// Not currently supported in rsgit.
+
+#[test]
+fn hash_file_write_std_to_db() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "--stdin", "-w"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(HELLO_CONTENT).unwrap();
+        }
+
+        let stdout = proc.wait_with_output().unwrap().stdout;
+
+        let mut expected_output = HELLO_SHA1.to_vec();
+        expected_output.push(10);
+
+        // TODO: Verify that blob exists.
+        // Needs implementation of cat-file.
+
+        assert_eq!(stdout, expected_output);
+    });
+}
+
+#[test]
+fn hash_file_write_std_to_db_args_swapped() {
+    // Same as previous test but with -w and --stdin args in opposite order.
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-w", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(HELLO_CONTENT).unwrap();
+        }
+
+        let stdout = proc.wait_with_output().unwrap().stdout;
+
+        let mut expected_output = HELLO_SHA1.to_vec();
+        expected_output.push(10);
+
+        // TODO: Verify that blob exists.
+        // Needs implementation of cat-file.
+
+        assert_eq!(stdout, expected_output);
+    });
+}
+
+// TODO: Add tests for hashing multiple files at same time.
+// Not currently supported in rsgit.
+
+// TODO: Add tests for hashing multiple files based on --stdin-paths at same time.
+// Not currently supported in rsgit.
+
+#[test]
+fn error_malformed_tree() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let malformed_tree_path = path.join("malformed-tree");
+
+        {
+            let mut f = File::create(&malformed_tree_path).unwrap();
+            f.write_all(b"abc").unwrap();
+        }
+
+        let malformed_tree_path_str = malformed_tree_path.to_str().unwrap();
+
+        let proc = Command::new(cmd)
+            .current_dir(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "tree", malformed_tree_path_str])
+            .spawn()
+            .unwrap();
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_malformed_mode_in_tree() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let malformed_tree_path = path.join("tree-with-malformed-mode");
+
+        {
+            let mut f = File::create(&malformed_tree_path).unwrap();
+            f.write_all(b"9100644 \0\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x20").unwrap();
+        }
+
+        let malformed_tree_path_str = malformed_tree_path.to_str().unwrap();
+
+        let proc = Command::new(cmd)
+            .current_dir(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "tree", malformed_tree_path_str])
+            .spawn()
+            .unwrap();
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_empty_filename_in_tree() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let malformed_tree_path = path.join("tree-with-malformed-mode");
+
+        {
+            let mut f = File::create(&malformed_tree_path).unwrap();
+            f.write_all(b"100644 \0\x01\x02\x03\x04\x05\x06\x07\x08\x09\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x20").unwrap();
+        }
+
+        let malformed_tree_path_str = malformed_tree_path.to_str().unwrap();
+
+        let proc = Command::new(cmd)
+            .current_dir(path)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "tree", malformed_tree_path_str])
+            .spawn()
+            .unwrap();
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_corrupt_commit() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "commit", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"").unwrap();
+        }
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_corrupt_tag() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "tag", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"").unwrap();
+        }
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_invalid_type_name() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "bogus", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"").unwrap();
+        }
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn error_truncated_type_name() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "bl", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"").unwrap();
+        }
+
+        let output = proc.wait_with_output();
+        assert!(!output.unwrap().status.success());
+    });
+}
+
+#[test]
+fn literally() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", "1234567890", "--literally", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"example").unwrap();
+        }
+
+        let output = proc.wait_with_output().unwrap();
+        println!(
+            "--- stderr\n\n{}\n",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert!(output.status.success());
+    });
+}
+
+#[test]
+fn write_literally() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&[
+                "hash-object",
+                "-w",
+                "-t",
+                "1234567890",
+                "--literally",
+                "--stdin",
+            ])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"example").unwrap();
+        }
+
+        let output = proc.wait_with_output().unwrap();
+        println!(
+            "--- stderr\n\n{}\n",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert!(output.status.success());
+    });
+}
+
+#[test]
+fn literally_long_type() {
+    common::compare_git_and_rsgit(|cmd, path| {
+        common::init_empty_repo(path);
+
+        let long_type = "1234567890".repeat(150);
+
+        let mut proc = Command::new(cmd)
+            .current_dir(path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .args(&["hash-object", "-t", &long_type, "--literally", "--stdin"])
+            .spawn()
+            .unwrap();
+
+        {
+            let stdin = proc.stdin.as_mut().unwrap();
+            stdin.write_all(b"example").unwrap();
+        }
+
+        let output = proc.wait_with_output().unwrap();
+        println!(
+            "--- stderr\n\n{}\n",
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        assert!(output.status.success());
+    });
+}


### PR DESCRIPTION
## Changes in This Pull Request
Adds a minimal implementation of the `hash-object` subcommand to the command-line interface.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- [ ] Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.
