### PR TITLE
Support arbitrary object types beyond the officially-recognized four.

### DIFF
--- a/src/object/kind.rs
+++ b/src/object/kind.rs
@@ -1,13 +1,19 @@
 use std::fmt::{self, Display, Formatter};
 
 /// Describes the fundamental git object type (blob, tree, commit, or tag).
+///
 /// We use the word `kind` here to avoid conflict with the Rust reserved word `type`.
-#[derive(Copy, Clone, Debug, PartialEq)]
+///
+/// Though not widely supported or used, you can also store objects of other
+/// made-up types by using the `--literally` flag, so this type supports storing
+/// other values, albeit less efficiently than it does the built-in types.
+#[derive(Clone, Debug, PartialEq)]
 pub enum Kind {
     Blob,
     Tree,
     Commit,
     Tag,
+    Other(Vec<u8>),
 }
 
 impl Display for Kind {
@@ -17,6 +23,7 @@ impl Display for Kind {
             Kind::Tree => write!(f, "tree"),
             Kind::Commit => write!(f, "commit"),
             Kind::Tag => write!(f, "tag"),
+            Kind::Other(name) => write!(f, "{}", String::from_utf8_lossy(name)),
         }
     }
 }
@@ -38,5 +45,8 @@ mod tests {
 
         let k = Kind::Tag;
         assert_eq!(k.to_string(), "tag");
+
+        let k = Kind::Other(b"arbitrary".to_vec());
+        assert_eq!(k.to_string(), "arbitrary");
     }
 }

--- a/src/repo/on_disk/tests/put_loose_object.rs
+++ b/src/repo/on_disk/tests/put_loose_object.rs
@@ -32,7 +32,7 @@ fn matches_command_line_git() {
     let r_path = rsgit_temp.path();
     let mut r = OnDisk::init(r_path).unwrap();
 
-    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    let o = Object::new(&Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
     r.put_loose_object(&o).unwrap();
 
     assert!(!dir_diff::is_different(tgr.path(), r_path).unwrap());
@@ -59,7 +59,7 @@ fn matches_command_line_git_large_file() {
     let r_path = rsgit_temp.path();
     let mut r = OnDisk::init(r_path).unwrap();
 
-    let o = Object::new(Kind::Blob, Box::new(test_content.to_vec())).unwrap();
+    let o = Object::new(&Kind::Blob, Box::new(test_content.to_vec())).unwrap();
     assert_eq!(object_id, o.id().to_string());
     r.put_loose_object(&o).unwrap();
 
@@ -75,7 +75,7 @@ fn error_cant_create_objects_dir() {
     let objects_dir = r_path.join(".git/objects/d6");
     fs::write(&objects_dir, "sand in the gears").unwrap();
 
-    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    let o = Object::new(&Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
     let err = r.put_loose_object(&o).unwrap_err();
 
     match err {
@@ -96,7 +96,7 @@ fn error_object_exists() {
     object_path.push("70460b4b4aece5915caf5c68d12f560a9fe3e4");
     fs::write(&object_path, "sand in the gears").unwrap();
 
-    let o = Object::new(Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
+    let o = Object::new(&Kind::Blob, Box::new(TEST_CONTENT.to_vec())).unwrap();
     let err = r.put_loose_object(&o).unwrap_err();
 
     match err {


### PR DESCRIPTION
## Changes in This Pull Request
Turns out you can create such by using `git hash-object --literally` so we need a way to represent those.

## Checklist
- [x] This PR represents a single feature, fix, or change.
- [x] All applicable changes have been documented.
- ~Any `TO DO` items (or similar) have been entered as GitHub issues and the link to that issue has been included in a comment.~ _n/a_
